### PR TITLE
53 Replaced the phrase 'changeable methods' with 'mutator methods'

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Below you will find descriptions of all rules available in **AEM Rules for Sonar
 - **AEM-15** Usage of ``synchronized`` keyword should be avoided if possible.
   - Usage of ``synchronized`` keyword should be avoided if possible. Check if using ``synchronized`` can be replaced with more sophisticated solution.
 
-- **AEM-17** No changeable methods invoked on ``ModifiableValueMap``
-  - ``ModifiableValueMap`` should be replaced by ``ValueMap`` if no changeable methods invoked.
+- **AEM-17** No mutator methods invoked on ``ModifiableValueMap``
+  - ``ModifiableValueMap`` should be replaced by ``ValueMap`` if no mutator methods are invoked.
 
 ## Possible bugs
 

--- a/src/main/java/com/cognifide/aemrules/checks/ModifiableValueMapUsageCheck.java
+++ b/src/main/java/com/cognifide/aemrules/checks/ModifiableValueMapUsageCheck.java
@@ -50,7 +50,7 @@ public class ModifiableValueMapUsageCheck extends BaseTreeVisitor implements Jav
 
 	protected static final String RULE_KEY = "AEM-17";
 
-	protected static final String RULE_MESSAGE = "No changeable methods invoked on ModifiableValueMap";
+	protected static final String RULE_MESSAGE = "No mutator methods invoked on ModifiableValueMap";
 
 	private JavaFileScannerContext context;
 

--- a/src/main/resources/rules/AEM-17.md
+++ b/src/main/resources/rules/AEM-17.md
@@ -12,17 +12,17 @@ If none of the above methods is called, `ValueMap` should be used instead.
 == Noncompliant Code Example
 
 ```
-	public Object getProperty(Resource resource) {
-		ModifiableValueMap createdResourceProperties = resource.adaptTo(ModifiableValueMap.class); // Noncompliant ValueMap should be used
-		return createdResourceProperties.get("propertyName");
-	}
+public Object getProperty(Resource resource) {
+	ModifiableValueMap createdResourceProperties = resource.adaptTo(ModifiableValueMap.class); // Noncompliant ValueMap should be used
+	return createdResourceProperties.get("propertyName");
+}
 ```
 
 == Compliant Solution
 
 ```
-	public Object getProperty(Resource resource) {
-		ValueMap createdResourceProperties = resource.getValueMap();
-		return createdResourceProperties.get("propertyName");
-	}
+public Object getProperty(Resource resource) {
+	ValueMap createdResourceProperties = resource.getValueMap();
+	return createdResourceProperties.get("propertyName");
+}
 ```

--- a/src/main/resources/rules/AEM-17.md
+++ b/src/main/resources/rules/AEM-17.md
@@ -1,27 +1,28 @@
-The ModifiableValueMap is an extension of the ValueMap which allows to modify and persist properties.
-It is checking user permissions and returns null if user has no permission to write.
+The [`ModifiableValueMap`](https://sling.apache.org/apidocs/sling7/org/apache/sling/api/resource/ModifiableValueMap.html) is an extension
+of the `ValueMap` which allows to modify and persist properties.
+It is checking user permissions and returns `null` if the user has no permission to write.
 
-Modifiable value map is only changeable through one of these methods:
-put(String, Object)
-putAll(java.util.Map)
-remove(Object)
+The modifiable value map is only changeable through any of the following methods:
+- `put(String, Object)`
+- `putAll(java.util.Map)`
+- `remove(Object)`
 
-If none of above methods used, ValueMap should be used.
+If none of the above methods is called, `ValueMap` should be used instead.
 
 == Noncompliant Code Example
 
-``
+```
 	public Object getProperty(Resource resource) {
 		ModifiableValueMap createdResourceProperties = resource.adaptTo(ModifiableValueMap.class); // Noncompliant ValueMap should be used
 		return createdResourceProperties.get("propertyName");
 	}
-``
+```
 
 == Compliant Solution
 
-``
+```
 	public Object getProperty(Resource resource) {
 		ValueMap createdResourceProperties = resource.getValueMap();
 		return createdResourceProperties.get("propertyName");
 	}
-``
+```


### PR DESCRIPTION
#53 Replaced the phrase 'changeable methods' with 'mutator methods' in docs and code.
Improved formatting of code snippets.