### PR TITLE
Modified AEM-6 and AEM-7 rules to be aware of the case when resourceR…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/Cognifide/AEM-Rules-for-SonarQube.svg?branch=master)](https://travis-ci.org/Cognifide/AEM-Rules-for-SonarQube)
 [![Coverage Status](https://coveralls.io/repos/github/Cognifide/AEM-Rules-for-SonarQube/badge.svg?branch=master)](https://coveralls.io/github/Cognifide/AEM-Rules-for-SonarQube?branch=master)
-[![Quality Gate](https://sonarqube.com/api/badges/gate?key=com.cognifide.aemrules%3Aaemrules)](https://sonarqube.com/overview?id=com.cognifide.aemrules%3Aaemrules)
+[![Quality Gate](https://sonarqube.com/api/badges/gate?key=com.cognifide.aemrules%3Aaemrules)](https://sonarqube.com/dashboard?id=com.cognifide.aemrules%3Aaemrules)
 # About AEM Rules for SonarQube
 
 ![AEM Rules for SonarQube](https://raw.githubusercontent.com/Cognifide/AEM-Rules-for-SonarQube/master/assets/logo.png)

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.version>5.6.1</sonar.version>
-        <sonar.java.plugin>4.0</sonar.java.plugin>
+        <sonar.java.plugin>4.6.0.8784</sonar.java.plugin>
         <coveralls.repo.token>4rVf3NGV0jyQ3EGrc8L86oEDoHWm6MgDD</coveralls.repo.token>
         <tagName>v${project.version}</tagName>
     </properties>
@@ -101,7 +101,11 @@
         </dependency>
 
         <!-- Unit Test dependencies -->
-
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.6.2</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -283,6 +287,27 @@
                         <goals>
                             <goal>format</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <excludeScope>provided</excludeScope>
+                            <outputDirectory>${project.build.directory}/test-jars</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,11 @@
             <version>1.3.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.annotations</artifactId>
+            <version>1.12.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -290,6 +295,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <!--
+                Maven dependency plugin is necessary for JavaCheckVerifier.verifyNoIssue to work properly. It copies
+                dependencies other than "provided" to test-jars folder.
+                Warning! If you remove it, tests which call JavaCheckVerifier.verifyNoIssue will
+                always pass, even if they are incorrect.
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>

--- a/src/main/java/com/cognifide/aemrules/checks/SessionShouldBeLoggedOut.java
+++ b/src/main/java/com/cognifide/aemrules/checks/SessionShouldBeLoggedOut.java
@@ -19,22 +19,26 @@
  */
 package com.cognifide.aemrules.checks;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.JavaFileScanner;
+import org.sonar.plugins.java.api.JavaFileScannerContext;
+import org.sonar.plugins.java.api.tree.AnnotationTree;
+import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
+import org.sonar.plugins.java.api.tree.IdentifierTree;
+import org.sonar.plugins.java.api.tree.MethodTree;
+import org.sonar.plugins.java.api.tree.Tree;
+import org.sonar.plugins.java.api.tree.VariableTree;
+
 import com.cognifide.aemrules.checks.visitors.CheckLoggedOutVisitor;
 import com.cognifide.aemrules.checks.visitors.FinallyBlockVisitor;
 import com.cognifide.aemrules.checks.visitors.FindSessionDeclarationVisitor;
 import com.cognifide.aemrules.tag.Tags;
 import com.google.common.collect.Sets;
-import org.sonar.check.Priority;
-import org.sonar.check.Rule;
-import org.sonar.plugins.java.api.JavaFileScanner;
-import org.sonar.plugins.java.api.JavaFileScannerContext;
-import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
-import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MethodTree;
-import org.sonar.plugins.java.api.tree.VariableTree;
-
-import java.util.Collection;
-import java.util.Set;
 
 @Rule(
 	key = SessionShouldBeLoggedOut.RULE_KEY,
@@ -48,7 +52,13 @@ public class SessionShouldBeLoggedOut extends BaseTreeVisitor implements JavaFil
 
 	public static final String RULE_MESSAGE = "Session should be logged out in finally block.";
 
+	private static final String ACTIVATE = "Activate";
+
+	private static final String DEACTIVATE = "Deactivate";
+
 	protected JavaFileScannerContext context;
+
+	private Collection<VariableTree> longSessions;
 
 	@Override
 	public void scanFile(JavaFileScannerContext javaFileScannerContext) {
@@ -58,14 +68,49 @@ public class SessionShouldBeLoggedOut extends BaseTreeVisitor implements JavaFil
 
 	@Override
 	public void visitMethod(MethodTree method) {
-		Collection<VariableTree> sessions = findSessionsInMethod(method);
-		for (VariableTree session : sessions) {
-			boolean closed = checkIfLoggedOut(method, session);
-			if (!closed) {
-				context.reportIssue(this, session, RULE_MESSAGE);
+		if (!checkIfLongSession(method)) {
+			Collection<VariableTree> sessions = findSessionsInMethod(method);
+			for (VariableTree session : sessions) {
+				boolean closed = checkIfLoggedOut(method, session);
+				if (!closed) {
+					context.reportIssue(this, session, RULE_MESSAGE);
+				}
 			}
 		}
 		super.visitMethod(method);
+	}
+
+	protected boolean checkIfLongSession(MethodTree method) {
+		List<AnnotationTree> annotations = method.modifiers().annotations();
+		for (AnnotationTree annotationTree : annotations) {
+			if (annotationTree.annotationType().is(Tree.Kind.IDENTIFIER)) {
+				IdentifierTree idf = (IdentifierTree) annotationTree.annotationType();
+				if (idf.name().equals(ACTIVATE)) {
+					checkIfLongSessionOpened(method);
+					return true;
+				}
+				else if (idf.name().equals(DEACTIVATE)) {
+					checkIfLongSessionClosed(method);
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private void checkIfLongSessionOpened(MethodTree method) {
+		longSessions = findSessionsInMethod(method);
+	}
+
+	private void checkIfLongSessionClosed(MethodTree method) {
+		if (longSessions != null) {
+			for (VariableTree longSession : longSessions) {
+				boolean closed = checkIfLoggedOut(method, longSession);
+				if (!closed) {
+					context.reportIssue(this, longSession, RULE_MESSAGE);
+				}
+			}
+		}
 	}
 
 	protected boolean checkIfLoggedOut(MethodTree method, VariableTree injector) {

--- a/src/test/files/checks/LongResourceResolverEvenListenerError.java
+++ b/src/test/files/checks/LongResourceResolverEvenListenerError.java
@@ -1,0 +1,65 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.example;
+
+import java.util.Map;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.jcr.api.SlingRepository;
+
+@Component
+public class LongResourceResolverEvenListenerError implements EventListener {
+
+	private ResourceResolver resolver; // Noncompliant {{ResourceResolver should be closed in finally block.}}
+
+	@Reference
+	private SlingRepository repository;
+
+	@Reference
+	private ResourceResolverFactory resourceResolverFactory;
+
+	@Activate
+	public void activate(final Map<String, String> config) throws RepositoryException, LoginException {
+		resolver = resourceResolverFactory.getAdministrativeResourceResolver(null);
+	}
+
+	@Deactivate
+	public void deactivate(final Map<String, String> config) throws RepositoryException {
+		try {
+			final Session session = resolver.adaptTo(Session.class);
+		} finally {
+		}
+	}
+
+	@Override
+	public void onEvent(final EventIterator events) {
+	}
+}

--- a/src/test/files/checks/LongSessionEventListener.java
+++ b/src/test/files/checks/LongSessionEventListener.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.example;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+import javax.jcr.observation.ObservationManager;
+import java.util.Map;
+
+@Component
+public class LongSessionEventListener implements EventListener {
+
+	private Session observationSession;
+
+	private ResourceResolver resolver;
+
+	@Reference
+	private SlingRepository repository;
+
+	@Reference
+	private ResourceResolverFactory resourceResolverFactory;
+
+	@Activate
+	public void activate(final Map<String, String> config) throws RepositoryException, LoginException {
+		observationSession = repository.loginAdministrative(null);
+		final ObservationManager observationManager = observationSession.getWorkspace().getObservationManager();
+		resolver = resourceResolverFactory.getAdministrativeResourceResolver(null);
+	}
+
+	@Deactivate
+	public void deactivate(final Map<String, String> config) throws RepositoryException {
+		try {
+			final ObservationManager observationManager = observationSession.getWorkspace().getObservationManager();
+
+			if (observationManager != null) {
+				observationManager.removeEventListener(this);
+			}
+		} finally {
+			if (observationSession != null) {
+				observationSession.logout();
+			}
+			if (resolver != null) {
+				resolver.close();
+			}
+		}
+	}
+
+	@Override
+	public void onEvent(final EventIterator events) {
+	}
+}

--- a/src/test/files/checks/LongSessionEventListenerError.java
+++ b/src/test/files/checks/LongSessionEventListenerError.java
@@ -1,0 +1,61 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.example;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.sling.jcr.api.SlingRepository;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.observation.EventIterator;
+import javax.jcr.observation.EventListener;
+import javax.jcr.observation.ObservationManager;
+import java.util.Map;
+
+@Component
+public class LongSessionEventListenerError implements EventListener {
+
+	private Session observationSession; // Noncompliant {{Session should be logged out in finally block.}}
+
+	@Reference
+	private SlingRepository repository;
+
+	@Activate
+	public void activate(final Map<String, String> config) throws RepositoryException {
+		observationSession = repository.loginAdministrative(null);
+		final ObservationManager observationManager = observationSession.getWorkspace().getObservationManager();
+	}
+
+	@Deactivate
+	public void deactivate(final Map<String, String> config) throws RepositoryException {
+		final ObservationManager observationManager = observationSession.getWorkspace().getObservationManager();
+
+		if (observationManager != null) {
+			observationManager.removeEventListener(this);
+		}
+	}
+
+	@Override
+	public void onEvent(final EventIterator events) {
+	}
+}

--- a/src/test/files/checks/LongSessionService.java
+++ b/src/test/files/checks/LongSessionService.java
@@ -77,10 +77,14 @@ public class LongSessionService implements EventListener {
 			registration.unregister();
 			registration = null;
 		}
-		unregisterObservation();
-		if (resolver != null) {
-			resolver.close();
-			resolver = null;
+		try {
+			unregisterObservation();
+		}
+		finally {
+			if (resolver != null) {
+				resolver.close();
+				resolver = null;
+			}
 		}
 	}
 

--- a/src/test/java/com/cognifide/aemrules/checks/ResourceResolverShouldBeClosedTest.java
+++ b/src/test/java/com/cognifide/aemrules/checks/ResourceResolverShouldBeClosedTest.java
@@ -19,8 +19,9 @@
  */
 package com.cognifide.aemrules.checks;
 
-import com.cognifide.aemrules.checks.resourceresolver.close.ResourceResolverShouldBeClosed;
 import org.junit.Test;
+
+import com.cognifide.aemrules.checks.resourceresolver.close.ResourceResolverShouldBeClosed;
 
 public class ResourceResolverShouldBeClosedTest extends AbstractBaseTest {
 
@@ -43,6 +44,20 @@ public class ResourceResolverShouldBeClosedTest extends AbstractBaseTest {
 		check = new ResourceResolverShouldBeClosed();
 		filename = "src/test/files/checks/LongSessionService.java";
 		verifyNoIssues();
+	}
+
+	@Test
+	public void checkResourceResolverClosedInDeactivateMethod() {
+		check = new ResourceResolverShouldBeClosed();
+		filename = "src/test/files/checks/LongSessionEventListener.java";
+		verifyNoIssues();
+	}
+
+	@Test
+	public void checkResourceResolverClosedInDeactivateMethodError() {
+		check = new ResourceResolverShouldBeClosed();
+		filename = "src/test/files/checks/LongResourceResolverEvenListenerError.java";
+		verify();
 	}
 
 }

--- a/src/test/java/com/cognifide/aemrules/checks/SessionShouldBeLoggedOutTest.java
+++ b/src/test/java/com/cognifide/aemrules/checks/SessionShouldBeLoggedOutTest.java
@@ -19,12 +19,12 @@
  */
 package com.cognifide.aemrules.checks;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import java.util.Arrays;
-import java.util.Collection;
 
 @RunWith(Parameterized.class)
 public class SessionShouldBeLoggedOutTest extends AbstractBaseTest {
@@ -40,7 +40,9 @@ public class SessionShouldBeLoggedOutTest extends AbstractBaseTest {
 				{ "src/test/files/checks/SessionLogoutFive.java", true},
 				{ "src/test/files/checks/SessionLogoutSix.java", true},
 				{ "src/test/files/checks/SessionLogoutSeven.java", true},
-				{ "src/test/files/checks/SessionLogoutEight.java", false}
+				{ "src/test/files/checks/SessionLogoutEight.java", false},
+				{ "src/test/files/checks/LongSessionEventListener.java", false},
+				{ "src/test/files/checks/LongSessionEventListenerError.java", true}
 		});
 	}
 


### PR DESCRIPTION
…esolver or Session can be closed in @Deactivate methods instead of closing right away. Second part of this commit is pom.xml modification which was done to fix behaviour of JavaCheckVerifier.verifyNoIssue method (which previously did not return correct results because of lack of jar files in target/test-jars folder)