### PR TITLE
#111 - Don't Introduce Extra Markup for HTL Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ Below you will find descriptions of all rules available in **AEM Rules for Sonar
   - HTL Templates should be placed in separate files. This helps to understand which code is meant to render a component and which code is re-used as a template.
   
 - **HTL-10** Use sly tags over redundant markup.
+    - HTL attributes should be wrapped in sly tags to avoid superfluous markup.
 
 - **HTL-11** Use existing HTML elements instead of adding extra sly tags.
+    - HTL attributes should be included in HTML markup without additional SLY tags. 
  
 
 ## Possible bugs

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Below you will find descriptions of all rules available in **AEM Rules for Sonar
   
 - **HTL-2** HTL Templates should be placed in separate files.
   - HTL Templates should be placed in separate files. This helps to understand which code is meant to render a component and which code is re-used as a template.
+  
+- **HTL-10** Use sly tags over redundant markup.
+
+- **HTL-11** Use existing HTML elements instead of adding extra sly tags.
+ 
 
 ## Possible bugs
 

--- a/src/main/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheck.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015-2018 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.cognifide.aemrules.htl.checks;
+
+import com.cognifide.aemrules.metadata.Metadata;
+import com.cognifide.aemrules.tag.Tags;
+import com.cognifide.aemrules.version.AemVersion;
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.TagNode;
+
+import java.util.Optional;
+
+@Rule(
+        key = AvoidExtraSlyTagsCheck.RULE_KEY,
+        name = AvoidExtraSlyTagsCheck.RULE_MESSAGE,
+        priority = Priority.MINOR,
+        tags = Tags.AEM
+)
+@AemVersion(
+        from = "6.0"
+)
+@Metadata(
+        technicalDebt = "5min"
+)
+public class AvoidExtraSlyTagsCheck extends AbstractHtlCheck {
+
+    public static final String RULE_KEY = "HTL-11";
+
+    public static final String RULE_MESSAGE = "Use existing HTML elements instead of adding extra sly tags";
+
+    private static final String SLY_TAG = "sly";
+
+    private static final ImmutableList SLY_ATTRIBUTES = ImmutableList.of("data-sly-use",
+            "data-sly-test",
+            "data-sly-call");
+
+    @Override
+    public void startElement(TagNode node) {
+        Optional.ofNullable(node.getParent())
+                .ifPresent(tagNode ->
+                {
+                    if (tagNode.getNodeName().equalsIgnoreCase(SLY_TAG)) {
+                        tagNode.getAttributes().stream()
+                                .map(Attribute::getName)
+                                .filter(SLY_ATTRIBUTES::contains)
+                                .findFirst()
+                                .ifPresent(s -> createViolation(tagNode.getStartLinePosition(), RULE_MESSAGE));
+                    }
+                });
+    }
+}

--- a/src/main/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheck.java
@@ -1,0 +1,74 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015-2018 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.cognifide.aemrules.htl.checks;
+
+import com.cognifide.aemrules.metadata.Metadata;
+import com.cognifide.aemrules.tag.Tags;
+import com.cognifide.aemrules.version.AemVersion;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
+import org.sonar.check.Priority;
+import org.sonar.check.Rule;
+import org.sonar.plugins.html.node.Attribute;
+import org.sonar.plugins.html.node.TagNode;
+
+@Rule(
+        key = UseSlyTagsOverRedundantMarkupCheck.RULE_KEY,
+        name = UseSlyTagsOverRedundantMarkupCheck.RULE_MESSAGE,
+        priority = Priority.MINOR,
+        tags = Tags.AEM
+)
+@AemVersion(
+        from = "6.0"
+)
+@Metadata(
+        technicalDebt = "5min"
+)
+public class UseSlyTagsOverRedundantMarkupCheck extends AbstractHtlCheck {
+
+    public static final String RULE_KEY = "HTL-10";
+
+    public static final String RULE_MESSAGE = "Use sly tags over redundant markup";
+
+    private static final String RULE_VIOLATION = "Try to reduce redundant markup with sly tags";
+
+    private static final String SLY_TAG = "sly";
+
+    private static final ImmutableList SLY_ATTRIBUTES = ImmutableList.of("data-sly-use",
+            "data-sly-test",
+            "data-sly-resource",
+            "data-sly-call");
+
+    @Override
+    public void startElement(TagNode node) {
+        if (!StringUtils.equalsAnyIgnoreCase(SLY_TAG, node.getNodeName()) && isReferenceBlockStatement(node)) {
+            createViolation(node.getStartLinePosition(), RULE_VIOLATION);
+        }
+    }
+
+    private boolean isReferenceBlockStatement(TagNode node) {
+        return node.getAttributes().stream()
+                .map(Attribute::getName)
+                .map(s -> StringUtils.substringBefore(s, "."))
+                .anyMatch(SLY_ATTRIBUTES::contains);
+    }
+
+}
+

--- a/src/main/resources/rules/HTL-10.md
+++ b/src/main/resources/rules/HTL-10.md
@@ -1,0 +1,16 @@
+If it's not possible to use an existing element, prefer sly tags over introducing superfluous markup that renders on the page.
+
+== Noncompliant Code Examples
+
+```
+<div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html"></div>
+```
+ 
+``` 
+<div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html" data-sly-unwrap></div>
+```
+
+== Compliant Solution
+```
+<sly data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html"></sly>
+```

--- a/src/main/resources/rules/HTL-11.md
+++ b/src/main/resources/rules/HTL-11.md
@@ -1,0 +1,22 @@
+Use existing HTML elements instead of adding extra sly tags.
+
+== Noncompliant Code Example
+```
+<sly data-sly-test="${model.visible}" data-sly-use="com.example.HeroModel">
+    <div class="myComponent">
+        <h1>${model.headline}</h1>
+        <p>${model.text}</p>
+    </div>
+</sly>
+```
+
+== Compliant Solution
+```
+<!--/* Non-Compliant */-->
+<div class="myComponent"
+     data-sly-test="${model.visible}"
+     data-sly-use="com.example.HeroModel">
+    <h1>${model.headline}</h1>
+    <p>${model.text}</p>
+</div>
+```

--- a/src/test/files/checks/htl/AvoidExtraSlyTagsCheck.html
+++ b/src/test/files/checks/htl/AvoidExtraSlyTagsCheck.html
@@ -1,0 +1,36 @@
+<!--
+
+    #%L
+    AEM Rules for SonarQube
+    %%
+    Copyright (C) 2015 Cognifide Limited
+    %%
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    #L%
+
+-->
+<!--/* Non-Compliant */-->
+<sly data-sly-test="${model.visible}" data-sly-use="com.example.HeroModel">
+    <div class="myComponent">
+        <h1>${model.headline}</h1>
+        <p>${model.text}</p>
+    </div>
+</sly>
+
+<!--/* Non-Compliant */-->
+<div class="myComponent"
+     data-sly-test="${model.visible}"
+     data-sly-use="com.example.HeroModel">
+    <h1>${model.headline}</h1>
+    <p>${model.text}</p>
+</div>

--- a/src/test/files/checks/htl/AvoidExtraSlyTagsCheck.html
+++ b/src/test/files/checks/htl/AvoidExtraSlyTagsCheck.html
@@ -19,15 +19,14 @@
     #L%
 
 -->
-<!--/* Non-Compliant */-->
-<sly data-sly-test="${model.visible}" data-sly-use="com.example.HeroModel">
+<sly data-sly-test="${model.visible}" data-sly-use="com.example.HeroModel"><!--/* Non-Compliant */-->
     <div class="myComponent">
         <h1>${model.headline}</h1>
         <p>${model.text}</p>
     </div>
 </sly>
 
-<!--/* Non-Compliant */-->
+
 <div class="myComponent"
      data-sly-test="${model.visible}"
      data-sly-use="com.example.HeroModel">

--- a/src/test/files/checks/htl/UseSlyTagsOverRedundantMarkupCheck.html
+++ b/src/test/files/checks/htl/UseSlyTagsOverRedundantMarkupCheck.html
@@ -1,0 +1,26 @@
+<!--
+
+    #%L
+    AEM Rules for SonarQube
+    %%
+    Copyright (C) 2015 Cognifide Limited
+    %%
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    #L%
+
+-->
+<div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html"></div> <!--/* Non-Compliant */-->
+
+<div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html" data-sly-unwrap></div>  <!--/* Non-Compliant */-->
+
+<sly data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html"></sly>

--- a/src/test/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheckTest.java
+++ b/src/test/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheckTest.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.cognifide.aemrules.htl.checks;
+
+import com.cognifide.aemrules.htl.AbstractBaseTest;
+import org.junit.Test;
+
+public class AvoidExtraSlyTagsCheckTest extends AbstractBaseTest {
+
+    @Test
+    public void avoidExtraSlyTags() {
+        check = new AvoidExtraSlyTagsCheck();
+        filename = "src/test/files/checks/htl/AvoidExtraSlyTagsCheck.html";
+        verify();
+    }
+}

--- a/src/test/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheckTest.java
+++ b/src/test/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheckTest.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * AEM Rules for SonarQube
+ * %%
+ * Copyright (C) 2015 Cognifide Limited
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.cognifide.aemrules.htl.checks;
+
+import com.cognifide.aemrules.htl.AbstractBaseTest;
+import org.junit.Test;
+
+public class UseSlyTagsOverRedundantMarkupCheckTest extends AbstractBaseTest {
+
+    @Test
+    public void checkRedundantSlyTags() {
+        check = new UseSlyTagsOverRedundantMarkupCheck();
+        filename = "src/test/files/checks/htl/UseSlyTagsOverRedundantMarkupCheck.html";
+        verify();
+    }
+}


### PR DESCRIPTION
Defined rules:
- **HTL-10** Use sly tags over redundant markup.
- **HTL-11** Use existing HTML elements instead of adding extra sly tags.