### PR TITLE
Rc1 issues

### DIFF
--- a/src/main/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/AvoidExtraSlyTagsCheck.java
@@ -23,6 +23,7 @@ import com.cognifide.aemrules.metadata.Metadata;
 import com.cognifide.aemrules.tag.Tags;
 import com.cognifide.aemrules.version.AemVersion;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.plugins.html.node.Attribute;
@@ -57,15 +58,18 @@ public class AvoidExtraSlyTagsCheck extends AbstractHtlCheck {
     @Override
     public void startElement(TagNode node) {
         Optional.ofNullable(node.getParent())
-                .ifPresent(tagNode ->
+                .ifPresent(parentNode ->
                 {
-                    if (tagNode.getNodeName().equalsIgnoreCase(SLY_TAG) && tagNode.getChildren().size() <= 1) {
-                        tagNode.getAttributes().stream()
+                    if (!StringUtils.equalsAnyIgnoreCase(SLY_TAG,node.getNodeName()) &&
+                            StringUtils.equalsAnyIgnoreCase(SLY_TAG, parentNode.getNodeName()) &&
+                            parentNode.getChildren().size() <= 1){
+                        parentNode.getAttributes().stream()
                                 .map(Attribute::getName)
                                 .filter(SLY_ATTRIBUTES::contains)
                                 .findFirst()
-                                .ifPresent(s -> createViolation(tagNode.getStartLinePosition(), RULE_MESSAGE));
+                                .ifPresent(s -> createViolation(parentNode.getStartLinePosition(), RULE_MESSAGE));
                     }
                 });
     }
 }
+

--- a/src/main/java/com/cognifide/aemrules/htl/checks/NamingAndReusingConditionsCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/NamingAndReusingConditionsCheck.java
@@ -68,6 +68,12 @@ public class NamingAndReusingConditionsCheck extends AbstractHtlCheck {
         updateConditionSets(expressions, node);
     }
 
+    @Override
+    public void endDocument() {
+        unnamedConditions.clear();
+        namedConditions.clear();
+    }
+
     private boolean isConditionReusedCorrectly(List<Expression> expressions, TagNode node) {
         String condition = clearExpressions(expressions).stream()
             .findFirst()

--- a/src/main/java/com/cognifide/aemrules/htl/checks/UseMostRestrictiveHtlContextCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/UseMostRestrictiveHtlContextCheck.java
@@ -54,7 +54,7 @@ public class UseMostRestrictiveHtlContextCheck extends AbstractHtlCheck {
         node.getAttributes().stream()
                 .filter(this::isHtmlDataAttribute)
                 .filter(this::isNotContextDefined)
-                .forEach(attribute -> createViolation(node.getStartLinePosition(), RULE_MESSAGE));
+                .forEach(attribute -> createViolation(attribute.getLine(), RULE_MESSAGE));
     }
 
     private boolean isHtmlDataAttribute(Attribute attribute) {

--- a/src/main/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheck.java
+++ b/src/main/java/com/cognifide/aemrules/htl/checks/UseSlyTagsOverRedundantMarkupCheck.java
@@ -56,22 +56,27 @@ public class UseSlyTagsOverRedundantMarkupCheck extends AbstractHtlCheck {
     private static final String SLY_TAG = "sly";
 
     private static final ImmutableList SLY_ATTRIBUTES = ImmutableList.of("data-sly-use",
-            "data-sly-test",
             "data-sly-include",
             "data-sly-resource",
             "data-sly-call");
 
     @Override
     public void startHtlElement(List<Expression> expressions, TagNode node) {
-        if (isWrappedInRedundantMarkup(node, expressions)) {
+        if (containsRedundantHtmlContainer(node) || isWrappedInRedundantMarkup(node, expressions)) {
             createViolation(node.getStartLinePosition(), RULE_VIOLATION);
         }
     }
 
     private boolean isWrappedInRedundantMarkup(TagNode node, List<Expression> expressions) {
-        return !StringUtils.equalsAnyIgnoreCase(SLY_TAG, node.getNodeName()) &&
+        return !StringUtils.equalsIgnoreCase(SLY_TAG, node.getNodeName()) &&
                 containsSlyCallAttributeWithExpression(node, expressions) &&
                 node.getChildren().isEmpty();
+    }
+
+    private boolean containsRedundantHtmlContainer(TagNode node){
+        return StringUtils.equalsIgnoreCase("div", node.getNodeName()) &&
+                node.getAttribute("data-sly-test") != null &&
+                node.getAttribute("class") == null;
     }
 
     private boolean isUsingCallAttributes(TagNode node){
@@ -80,7 +85,6 @@ public class UseSlyTagsOverRedundantMarkupCheck extends AbstractHtlCheck {
                 .map(s -> StringUtils.substringBefore(s, "."))
                 .anyMatch(SLY_ATTRIBUTES::contains);
     }
-
 
     private boolean containsSlyCallAttributeWithExpression(TagNode node, List<Expression> expressions) {
         if (expressions.isEmpty()) {

--- a/src/main/resources/rules/HTL-1.md
+++ b/src/main/resources/rules/HTL-1.md
@@ -2,11 +2,13 @@ Always Place HTL Attributes After the Ones that are Part of the Markup
 It's easier to understand HTL code if the attributes processed server-side are visually separated from the ones used at the front-end.
 
 == Noncompliant Code Example
+
 ``
 <div data-sly-test="${model.enabled}" class="decorated" data-sly-unwrap="${!model.decorated}"> // Bad - mixing HTL attributes with other ones
 ``
 
 == Compliant Solution
+
 ``
 <div class="decorated" data-sly-test="${model.enabled}" data-sly-unwrap="${!model.decorated}"> // Good - HTL-specific attributes grouped at the end of the element
 ``

--- a/src/main/resources/rules/HTL-10.md
+++ b/src/main/resources/rules/HTL-10.md
@@ -4,7 +4,6 @@ If it's not possible to use an existing element, prefer sly tags over introducin
 
 ``
 <div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html"></div>
-
 <div data-sly-use.model="com.example.Model" data-sly-use.templates="templates.html" data-sly-unwrap></div>
 ``
 

--- a/src/main/resources/rules/HTL-12.md
+++ b/src/main/resources/rules/HTL-12.md
@@ -1,14 +1,10 @@
 Use the most restrictive HTL context possible.
 
 == Noncompliant Code Example
-``
-<div data-index-number=${model.index} >
-``
-    
+`<div data-index-number="${model.index}"></div>`
+
 == Compliant Solution
-``
-<div data-index-number=${model.index @ context='number'} >
-``
+`<div data-index-number="${model.index @ context='number'}"></div>`
 
 Available markup context:
 * html          - Use this in case you want to output HTMLRemoves markup that may contain XSS risks

--- a/src/main/resources/rules/HTL-12.md
+++ b/src/main/resources/rules/HTL-12.md
@@ -1,10 +1,10 @@
 Use the most restrictive HTL context possible.
 
 == Noncompliant Code Example
-`<div data-index-number="${model.index}"></div>`
+``<div data-index-number="${model.index}"></div>``
 
 == Compliant Solution
-`<div data-index-number="${model.index @ context='number'}"></div>`
+``<div data-index-number="${model.index @ context='number'}"></div>``
 
 Available markup context:
 * html          - Use this in case you want to output HTMLRemoves markup that may contain XSS risks

--- a/src/main/resources/rules/HTL-13.md
+++ b/src/main/resources/rules/HTL-13.md
@@ -6,8 +6,9 @@ Avoid using 'unsafe' display context, it disables XSS protection completely.
     <p>${model.text @ context='unsafe'}</p>
 </div>
 ``
-    
+
 == Compliant Solution
+
 ``
 <div class="my-component>
     <p>${model.text}</p>

--- a/src/main/resources/rules/HTL-14.md
+++ b/src/main/resources/rules/HTL-14.md
@@ -5,7 +5,8 @@ HTL expressions in HTML comments should have defined context.
 ``
 <!--[if IE]><link rel="shortcut icon" href="${site.root}/images/favicon/favicon.ico?v2"><![endif]-->
 ``
-    
+
+
 == Compliant Solution
 
 ``

--- a/src/main/resources/rules/HTL-15.md
+++ b/src/main/resources/rules/HTL-15.md
@@ -3,11 +3,14 @@ Use Camel Case in identifiers:
  * template names
 
 == Noncompliant Code Example
+
 ``
 <sly data-sly-template.COMPONENT_VALIDATION>
 <sly data-sly-use.GalleryModel="com.example.GalleryModel">
 ``
+
 == Compliant Solution
+
 ``
 <sly data-sly-template.componentValidation>
 <sly data-sly-use.galleryModel="com.example.GalleryModel">

--- a/src/main/resources/rules/HTL-2.md
+++ b/src/main/resources/rules/HTL-2.md
@@ -1,6 +1,7 @@
 HTL Templates should be placed in separate files. This helps to understand which code is meant to render a component and which code is re-used as a template. Additionally, component-specific code can be safely removed. It should be immediately obvious whether or not some code is re-used across the codebase.
 
 == Noncompliant Code Example
+
 ``
 <template data-sly-template.image="${@ source, description}">
     <img src="${source}" alt="${description}" title="${description}"/>

--- a/src/main/resources/rules/HTL-3.md
+++ b/src/main/resources/rules/HTL-3.md
@@ -2,6 +2,7 @@ HTL provides implicit variables in data-sly-list and data-sly-repeat blocks.
 Try to avoid them and use explicit names clarifying the role of the objects instead.
 
  == Noncompliant Code Example
+ 
 ``
 <ul data-sly-list="${model.downloadableFiles}"> 
     <li>
@@ -9,7 +10,9 @@ Try to avoid them and use explicit names clarifying the role of the objects inst
     </li>
 </ul>
 ``
+
 == Compliant Solution
+
 ``
 <ul data-sly-list.file="${model.downloadableFiles}">
     <li>

--- a/src/main/resources/rules/HTL-4.md
+++ b/src/main/resources/rules/HTL-4.md
@@ -11,9 +11,7 @@ Always try to re-use existing conditions, so the code is more readable.
 <span class="uber-mode__bottom-bar" data-sly-test="${uberModeHelper.uberModeEnabled || forceUberMode}"></span>
 ``
 
-
 == Compliant Solution
-
 
 ``
 <span class="uber-mode__top-bar" data-sly-test.uberMode="${uberModeHelper.uberModeEnabled || forceUberMode}">

--- a/src/main/resources/rules/HTL-4.md
+++ b/src/main/resources/rules/HTL-4.md
@@ -10,8 +10,10 @@ Always try to re-use existing conditions, so the code is more readable.
 </span>
 <span class="uber-mode__bottom-bar" data-sly-test="${uberModeHelper.uberModeEnabled || forceUberMode}"></span>
 ``
-    
+
+
 == Compliant Solution
+
 
 ``
 <span class="uber-mode__top-bar" data-sly-test.uberMode="${uberModeHelper.uberModeEnabled || forceUberMode}">

--- a/src/main/resources/rules/HTL-5.md
+++ b/src/main/resources/rules/HTL-5.md
@@ -1,12 +1,12 @@
 Always use HTL style of commenting
 
- == Noncompliant Code Example
+== Noncompliant Code Example
 
 ``
     <!-- Potentially bad, plain HTML comments will be visible on the page -->
 ``
 
- == Compliant Solution
+== Compliant Solution
 
 ``
     <!--/* Good, this comment will not be rendered */-->

--- a/src/test/files/checks/htl/CamelCaseCheck.html
+++ b/src/test/files/checks/htl/CamelCaseCheck.html
@@ -1,3 +1,24 @@
+<!--
+
+    #%L
+    AEM Rules for SonarQube
+    %%
+    Copyright (C) 2015-2019 Cognifide Limited
+    %%
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    #L%
+
+-->
 <sly data-sly-template.COMPONENT_VALIDATION></sly> <!--/* Non-Compliant */-->
 <sly data-sly-use.GalleryModel="com.example.GalleryModel"></sly> <!--/* Non-Compliant */-->
 <sly data-sly-template.componentValidation></sly>

--- a/src/test/files/checks/htl/ExplicitNamesInLoopsCheck.html
+++ b/src/test/files/checks/htl/ExplicitNamesInLoopsCheck.html
@@ -1,20 +1,24 @@
 <!--
-     #%L
+
+    #%L
     AEM Rules for SonarQube
     %%
-    Copyright (C) 2015 Cognifide Limited
+    Copyright (C) 2015-2019 Cognifide Limited
     %%
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-          http://www.apache.org/licenses/LICENSE-2.0
-     Unless required by applicable law or agreed to in writing, software
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
     #L%
- -->
+
+-->
 <ul data-sly-list="${model.downloadableFiles}"> <!--/* Non-Compliant */-->
   <li>
     <a href="${item.url}">${item.name}</a>

--- a/src/test/files/checks/htl/UseSlyTagsOverRedundantMarkupCheck.html
+++ b/src/test/files/checks/htl/UseSlyTagsOverRedundantMarkupCheck.html
@@ -32,12 +32,10 @@
     </div>
 </sly>
 
-
 <div class="myComponent" data-sly-test="${model.visible}" data-sly-use="com.example.HeroModel">
     <h1>${model.headline}</h1>
     <p>${model.text}</p>
 </div>
-
 
 <div data-sly-use.model="com.example.model.PageConfig"
         id="banner"
@@ -47,4 +45,8 @@
 
 <div data-sly-call="${lib.two @ title=properties.jcr:title, resource=resource.parent}"></div> <!--/* Non-Compliant */-->
 
+<p data-sly-test="${model.columnTitle}">${model.columnTitle}</p>
 
+<span data-sly-test="${wcmmode.edit}">Power Reviews Detailed View</span>
+
+<div data-sly-test="${model.columnTitle}">${model.columnTitle}</div> <!--/* Non-Compliant */-->


### PR DESCRIPTION
* HTL-11 - When sly tag is wrapped with another sly tag violation should be skipped
* HTL-10 - Avoid false-positive violation on for data-sly-test attribute
* HTL-4 - Conditions leaks between documents
* miscellaneous formatting fixes in rules description